### PR TITLE
replaced "ou=pizza" with value pulled from config.yml

### DIFF
--- a/src/main/scala/moe/pizza/auth/Main.scala
+++ b/src/main/scala/moe/pizza/auth/Main.scala
@@ -83,7 +83,7 @@ object Main {
               val lc = new LdapClient("localhost", configfile.get.embeddedldap.port, "uid=admin,ou=system", internalpassword)
               val broadcasters = configfile.get.auth.pingbot.map{c => new XmppBroadcastService(c.host, c.password)}.toList
               println(s"constructed broadcasters from ${configfile.get.auth.pingbot}")
-              val webapp = new Webapp(configfile.get, graders, 9021, new LdapUserDatabase(lc, ldap.directoryService.getSchemaManager), None, None, None, broadcasters)
+              val webapp = new Webapp(configfile.get, graders, 9021, new LdapUserDatabase(lc, ldap.directoryService.getSchemaManager, configfile.get.embeddedldap.basedn), None, None, None, broadcasters)
               val builder = BlazeBuilder.mountService(webapp.router).bindSocketAddress(new InetSocketAddress("127.0.0.1", 9021))
               val server = builder.run
               println(s"LDAP server started on localhost:${configfile.get.embeddedldap.port} with admin password ${internalpassword}")

--- a/src/test/scala/moe/pizza/auth/adapters/LdapUserDatabaseSpec.scala
+++ b/src/test/scala/moe/pizza/auth/adapters/LdapUserDatabaseSpec.scala
@@ -34,7 +34,7 @@ class LdapUserDatabaseSpec extends FlatSpec with MustMatchers {
       // use the client
       val c = new LdapClient("localhost", 3390, "uid=admin,ou=system", "testpassword")
       // wrap it in an LUD
-      val lud = new LdapUserDatabase(c, schema)
+      val lud = new LdapUserDatabase(c, schema,"ou=pizza")
       val p = new Pilot("lucia_denniard", Pilot.Status.internal, "Confederation of xXPIZZAXx", "Love Squad", "Lucia Denniard", "lucia@pizza.moe", Pilot.OM.createObjectNode(), List(), List(), List())
       lud.addUser(p, "luciapassword") must equal(true)
       c.withConnection { con =>
@@ -59,7 +59,7 @@ class LdapUserDatabaseSpec extends FlatSpec with MustMatchers {
       // use the client
       val c = new LdapClient("localhost", 3391, "uid=admin,ou=system", "testpassword")
       // wrap it in an LUD
-      val lud = new LdapUserDatabase(c, schema)
+      val lud = new LdapUserDatabase(c, schema,"ou=pizza")
       val p = new Pilot("lucia_denniard", Pilot.Status.internal, "Confederation of xXPIZZAXx", "Love Squad", "Lucia Denniard", "lucia@pizza.moe", Pilot.OM.createObjectNode(), List(), List(), List())
       lud.addUser(p, "luciapassword") must equal(true)
       lud.getUser("lucia_denniard") must equal(Some(p))
@@ -83,7 +83,7 @@ class LdapUserDatabaseSpec extends FlatSpec with MustMatchers {
       // use the client
       val c = new LdapClient("localhost", 3392, "uid=admin,ou=system", "testpassword")
       // wrap it in an LUD
-      val lud = new LdapUserDatabase(c, schema)
+      val lud = new LdapUserDatabase(c, schema,"ou=pizza")
       val p = new Pilot("lucia_denniard", Pilot.Status.internal, "Confederation of xXPIZZAXx", "Love Squad", "Lucia Denniard", "lucia@pizza.moe", Pilot.OM.createObjectNode(), List(), List(), List())
       lud.addUser(p, "luciapassword") must equal(true)
       lud.getUser("lucia_denniard") must equal(Some(p))
@@ -106,7 +106,7 @@ class LdapUserDatabaseSpec extends FlatSpec with MustMatchers {
       // use the client
       val c = new LdapClient("localhost", 3393, "uid=admin,ou=system", "testpassword")
       // wrap it in an LUD
-      val lud = new LdapUserDatabase(c, schema)
+      val lud = new LdapUserDatabase(c, schema,"ou=pizza")
       val p = new Pilot("lucia_denniard", Pilot.Status.internal, "Confederation of xXPIZZAXx", "Love Squad", "Lucia Denniard", "lucia@pizza.moe", Pilot.OM.createObjectNode(), List(), List(), List())
       lud.addUser(p, "luciapassword") must equal(true)
       lud.getUser("lucia_denniard") must equal(Some(p))
@@ -132,7 +132,7 @@ class LdapUserDatabaseSpec extends FlatSpec with MustMatchers {
       // use the client
       val c = new LdapClient("localhost", 3394, "uid=admin,ou=system", "testpassword")
       // wrap it in an LUD
-      val lud = new LdapUserDatabase(c, schema)
+      val lud = new LdapUserDatabase(c, schema,"ou=pizza")
       val p = new Pilot("lucia_denniard", Pilot.Status.internal, "Confederation of xXPIZZAXx", "Love Squad", "Lucia Denniard", "lucia@pizza.moe", Pilot.OM.createObjectNode(), List(), List(), List())
       lud.addUser(p, "luciapassword") must equal(true)
       lud.getUser("lucia_denniard") must equal(Some(p))
@@ -163,9 +163,9 @@ class LdapUserDatabaseSpec extends FlatSpec with MustMatchers {
       // use the client
       val c = new LdapClient("localhost", 3395, "uid=admin,ou=system", "testpassword")
       // wrap it in an LUD
-      val lud = new LdapUserDatabase(c, schema)
+      val lud = new LdapUserDatabase(c, schema,"ou=pizza")
       val p = new Pilot("lucia_denniard", Pilot.Status.internal, "Confederation of xXPIZZAXx", "Love Squad", "Lucia Denniard", "lucia@pizza.moe", Pilot.OM.createObjectNode(), List(), List(), List())
-      lud.addUser(p, "luciapassword") must equal(true)
+      lud.addUser(p, "sluciapassword") must equal(true)
       val r = lud.getUser("lucia_denniard")
       val p2 = p.copy(alliance = "No Alliance")
       lud.updateUser(p2) must equal(true)


### PR DESCRIPTION
this was done by adding a parameter to the LdapUserDatabase class.

tests still pass,  I was able to bring up a test environment with a different basedn "ou=ncdot" by copying these files:
- `/src/main/resources/schemas/pizza.schema`
- `/src/main/resources/schemasds/pizza.ldif`
- `/src/main/resources/schemasds/pizzatop.ldif`

and replacing pizza with ncdot in filename and contents.
the ou name was extracted from the basedn string with `basedn.replace("ou=","")`. 
