### PR TITLE
Account management UI: email + password

### DIFF
--- a/src/main/twirl/templates/account.scala.html
+++ b/src/main/twirl/templates/account.scala.html
@@ -16,23 +16,68 @@
                         <tr>
                             <th>Main Character</th><td>@pilot.characterName</td>
                         </tr>
-                        <tr>
-                            <th>Email</th><td><input name="email" value="@pilot.email" required/></td>
-                        </tr>
-                        <tr>
-                            <th>New Password</th><td><input type="password" name="password" id="password" /></td>
-                        </tr>
-                        <tr>
-                            <th>Confirm New Password</th><td><input type="password" name="password_confirm" id="password_confirm" /></td>
-                        </tr>
-                        <tr>
-                            <th>Confirm Old Password</th><td><input type="password" name="oldpassword" id="oldpassword" /></td>
-                        </tr>
                     </table>
-                    <button type="submit" class="btn btn-default">Update</button>
+                    <!--<button type="submit" class="btn btn-default">Update</button>-->
                 </form>
                 <script>
                         $( "#update_account" ).validate({
+                            rules: {
+
+                            }
+                        });
+                </script>
+
+
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="panel panel-primary">
+            <div class="panel-heading"><h3 class="panel-title">Password</h3></div>
+            <div class="panel-body">
+                <form role="form" id="update_password" action="/account/update/password" method="post">
+                    <table class="table table-striped">
+                        <tr>
+                            <th>New Password</th><td><input class="form-control" type="password" name="password" id="password" /></td>
+                        </tr>
+                        <tr>
+                            <th>Confirm New Password</th><td><input class="form-control" type="password" name="password_confirm" id="password_confirm" /></td>
+                        </tr>
+                        <tr>
+                            <th>Old Password</th><td><input class="form-control" type="password" name="oldpassword" id="oldpassword" /></td>
+                        </tr>
+                    </table>
+                    <button type="submit" class="btn btn-primary">Update</button>
+                </form>
+                <script>
+                        $( "#update_password" ).validate({
+                            rules: {
+                                password: "required",
+                                password_confirm: {
+                                    equalTo: "#password"
+                                }
+                            }
+                        });
+                </script>
+
+
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="panel panel-primary">
+            <div class="panel-heading"><h3 class="panel-title">Email</h3></div>
+            <div class="panel-body">
+                <form role="form" id="update_email" action="/account/update/email" method="post">
+                    <table class="table table-striped">
+                        <tr>
+                            <th>Email</th><td><input class="form-control" name="email" value="@pilot.email" required/></td>
+                        </tr>
+                    </table>
+                    <button type="submit" class="btn btn-primary">Update</button>
+                </form>
+                <script>
+                        $( "#update_email" ).validate({
                             rules: {
                                 email: {
                                     required: true,

--- a/src/main/twirl/templates/account.scala.html
+++ b/src/main/twirl/templates/account.scala.html
@@ -43,9 +43,6 @@
                         <tr>
                             <th>Confirm New Password</th><td><input class="form-control" type="password" name="password_confirm" id="password_confirm" /></td>
                         </tr>
-                        <tr>
-                            <th>Old Password</th><td><input class="form-control" type="password" name="oldpassword" id="oldpassword" /></td>
-                        </tr>
                     </table>
                     <button type="submit" class="btn btn-primary">Update</button>
                 </form>

--- a/src/main/twirl/templates/base.scala.html
+++ b/src/main/twirl/templates/base.scala.html
@@ -33,6 +33,7 @@
         <nav id="navcbars" class="collapse navbar-collapse navbar-ex1-collapse" role="navigtion">
             <ul class="nav navbar-nav">
                 @if(pilot.isDefined) {
+                    <li><a href="/account">Account</a></li>
                     <li><a href="/groups">Groups</a></li>
                 }
                 @if(pilot.isDefined && pilot.get.getGroups.contains("admin")) {
@@ -45,8 +46,8 @@
 
             <ul class="nav navbar-nav navbar-right">
                 @if(pilot.isDefined) {
-                    <li class="navbar-text">
-                        @pilot.get.characterName
+                    <li>
+                        <a href="/account">@pilot.get.characterName</a>
                     </li>
                     <li>
                         <a href="/logout" class="btn btn-primary" role="button">Logout</a>

--- a/src/test/scala/moe/pizza/auth/webapp/DynamicRouterSpec.scala
+++ b/src/test/scala/moe/pizza/auth/webapp/DynamicRouterSpec.scala
@@ -5,6 +5,10 @@ import moe.pizza.auth.config.ConfigFile.{
   AuthConfig,
   ConfigFile
 }
+import moe.pizza.auth.ldap.server.EmbeddedLdapServer
+import moe.pizza.auth.ldap.client.LdapClient
+import moe.pizza.auth.ldap.client.LdapClient._
+import moe.pizza.auth.adapters.LdapUserDatabase
 import moe.pizza.auth.graphdb.EveMapDb
 import moe.pizza.auth.interfaces.{BroadcastService, PilotGrader, UserDatabase}
 import moe.pizza.auth.models.Pilot
@@ -28,10 +32,23 @@ import moe.pizza.eveapi.XMLApiResponse
 import org.joda.time.DateTime
 import org.mockito.Matchers._
 
+
+import java.io.File
+import java.util.UUID
+
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class DynamicRouterSpec extends FlatSpec with MockitoSugar with MustMatchers {
+
+  def createTempFolder(suffix: String): File = {
+    val base = new File(new File(System.getProperty("java.io.tmpdir")),
+                        "pizza-auth-test")
+    base.delete()
+    val dir = new File(base, UUID.randomUUID().toString + suffix)
+    dir.mkdirs()
+    dir
+  }
 
   "DynamicRouter" should "redirect to the CREST login URL when logging in" in {
     val config = mock[ConfigFile]
@@ -1588,8 +1605,8 @@ class DynamicRouterSpec extends FlatSpec with MockitoSugar with MustMatchers {
     val resp = res.run
     resp.status must equal(Status.Ok)
     val bodytxt = EntityDecoder.decodeString(resp)(Charset.`UTF-8`).run
-    // should show the currently logged in user, and a logout button
-    assert(bodytxt contains "/account/update")
+    assert(bodytxt contains "/account/update/email")
+    assert(bodytxt contains "/account/update/password")
     assert(bodytxt contains "Bob McName")
   }
   "DynamicRouter's account page" should "change people's emails" in {
@@ -1646,6 +1663,91 @@ class DynamicRouterSpec extends FlatSpec with MockitoSugar with MustMatchers {
       "Successfully updated email.")
     verify(ud).updateUser(
       bob.copy(email = "newbob@newbobcorp.corp"))
+  }
+  "DynamicRouter's account page" should "change people's passwords" in {
+    val tempfolder = createTempFolder("passwordchangetest")
+    try {
+      val config = mock[ConfigFile]
+      val authconfig = mock[AuthConfig]
+      val pg = mock[PilotGrader]
+      val crest = mock[CrestApi]
+      val db = mock[EveMapDb]
+      val update = mock[Update]
+      when(config.auth).thenReturn(authconfig)
+      when(crest.redirect("login", Webapp.defaultCrestScopes))
+        .thenReturn("http://login.eveonline.com/whatever")
+
+      val server = new EmbeddedLdapServer(tempfolder.toString,
+                                          "ou=pizza",
+                                          "localhost",
+                                          3392,
+                                          instanceName =
+                                            "pizza-auth-webap-password-change-test")
+      server.setPassword("testpassword")
+      server.start()
+      // TODO find a way to make a schemamanager without the server
+      val schema = server.directoryService.getSchemaManager
+      // use the client
+      val c = new LdapClient("localhost",
+                             3392,
+                             "uid=admin,ou=system",
+                             "testpassword")
+      // wrap it in an LUD
+      val ud = new LdapUserDatabase(c, schema, "ou=pizza")
+      val p = new Pilot("lucia_denniard",
+                        Pilot.Status.internal,
+                        "Confederation of xXPIZZAXx",
+                        "Love Squad",
+                        "Lucia Denniard",
+                        "lucia@pizza.moe",
+                        Pilot.OM.createObjectNode(),
+                        List(),
+                        List(),
+                        List())
+      ud.addUser(p, "luciapassword") must equal(true)
+      ud.getUser("lucia_denniard") must equal(Some(p))
+      ud.authenticateUser("lucia_denniard", "notluciapassword") must equal(
+        None)
+      ud.authenticateUser("lucia_denniard", "luciapassword") must equal(
+        Some(p))
+
+      val app = new Webapp(config,
+                         pg,
+                         9021,
+                         ud,
+                         crestapi = Some(crest),
+                         mapper = Some(db),
+                         updater = Some(update))
+
+      //when(ud.updateUser(anyObject())).thenReturn(true)
+
+      val req = Request(
+        method = Method.POST,
+        uri = Uri.uri("/account/update/password"),
+        body = UrlForm.entityEncoder
+          .toEntity(
+            UrlForm("password" -> "luciaNEWpassword"))
+          .run
+          .body
+      )
+      val reqwithsession = req.copy(
+        attributes = req.attributes.put(
+          SessionManager.HYDRATEDSESSION,
+          new HydratedSession(List.empty[Alert], Some(p), None)))
+      val res = app.dynamicWebRouter(reqwithsession)
+
+      val resp = res.run
+      resp.getSession.get.alerts.head.content must equal(
+        "Successfully changed password.")
+
+      ud.authenticateUser("lucia_denniard", "luciapassword") must equal(None)
+      ud.authenticateUser("lucia_denniard", "luciaNEWpassword") must equal(
+        Some(p))
+
+      server.stop()
+    } finally {
+      tempfolder.delete()
+    }
   }
   "DynamicRouter's routes which require a session" should "redirect back to /" in {
     val config = mock[ConfigFile]


### PR DESCRIPTION
Implemented routes for updateing / changing email and password for accounts.

Included links to the /account page in base template.

Changed /account template to show more columns and seperate forms for email and password.

Included tests for all routes.
